### PR TITLE
Update dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import numpy
 
 from setuptools import setup
 from setuptools import Extension

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,11 @@ setup(
                     + "---------\n\n"
                     + open("HISTORY.md").read(),
     package_data={"": ["README.md", "HISTORY.md"]},
-    install_requires=["numpy==1.14.3", 
-		      "scipy==1.1.0",
-		      "acor==1.1.1",
-		      "mpi4py==3.0.0"],
+    install_requires=[
+        "numpy",
+		"scipy",
+		"acor",
+		"mpi4py"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ import os
 import sys
 
 from setuptools import setup
-from setuptools import Extension
 
 import PTMCMCSampler
 
@@ -28,10 +27,12 @@ setup(
                     + open("HISTORY.md").read(),
     package_data={"": ["README.md", "HISTORY.md"]},
     install_requires=[
+        # use an acor fork that can be installed via pip install -e
+        "acor @ git+https://github.com/JBEI/acor.git",
+        "mpi4py",
         "numpy",
 		"scipy",
-		"acor",
-		"mpi4py"],
+	],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Updates dependencies to fix pip install.  Tested dependency versions should be pinned in the client application (ART), not in the library itself.

From the Python [packaging guidance](https://packaging.python.org/discussions/install-requires-vs-requirements/):

```
It is not considered best practice to use install_requires to pin dependencies to specific versions, or to specify sub-dependencies (i.e. dependencies of your dependencies). This is overly-restrictive, and prevents the user from gaining the benefit of dependency upgrades.
```